### PR TITLE
Bucket 2: Pagination & coverage (dynamic fetch-all)

### DIFF
--- a/FBI.py
+++ b/FBI.py
@@ -46,3 +46,29 @@ def compute_total_pages(total, page_size, max_pages=None):
     if max_pages is not None:
         pages = min(pages, max_pages)
     return pages
+
+
+def iter_all_items(session, cfg):
+    """Yield every item across all pages, deriving page count from the API total."""
+    first = fetch_page(session, 1, cfg.page_size)
+    if first is None:
+        logger.error("Could not fetch first page; nothing to do")
+        return
+    for item in first.get("items", []):
+        yield item
+
+    total = first.get("total", 0)
+    total_pages = compute_total_pages(total, cfg.page_size, cfg.max_pages)
+    logger.info("Total records reported: %s across %d page(s)", total, total_pages)
+
+    for page in range(2, total_pages + 1):
+        data = fetch_page(session, page, cfg.page_size)
+        if data is None:
+            continue
+        items = data.get("items", [])
+        if not items:
+            logger.info("Page %d returned no items; stopping early", page)
+            break
+        for item in items:
+            yield item
+        time.sleep(cfg.delay)

--- a/FBI.py
+++ b/FBI.py
@@ -42,6 +42,8 @@ def fetch_page(session, page, page_size, timeout=DEFAULT_TIMEOUT, retries=DEFAUL
 
 def compute_total_pages(total, page_size, max_pages=None):
     """Number of pages needed for `total` items at `page_size`, optionally capped."""
+    if page_size <= 0:
+        raise ValueError("page_size must be positive, got {}".format(page_size))
     pages = math.ceil(total / page_size) if total > 0 else 0
     if max_pages is not None:
         pages = min(pages, max_pages)
@@ -54,14 +56,17 @@ def iter_all_items(session, cfg):
     if first is None:
         logger.error("Could not fetch first page; nothing to do")
         return
-    for item in first.get("items", []):
-        yield item
 
-    total = first.get("total", 0)
+    # `or 0` guards against both a missing key and an explicit null total.
+    total = first.get("total") or 0
     total_pages = compute_total_pages(total, cfg.page_size, cfg.max_pages)
     logger.info("Total records reported: %s across %d page(s)", total, total_pages)
 
+    for item in first.get("items", []):
+        yield item
+
     for page in range(2, total_pages + 1):
+        time.sleep(cfg.delay)  # throttle before each subsequent fetch, success or not
         data = fetch_page(session, page, cfg.page_size)
         if data is None:
             continue
@@ -71,4 +76,3 @@ def iter_all_items(session, cfg):
             break
         for item in items:
             yield item
-        time.sleep(cfg.delay)

--- a/FBI.py
+++ b/FBI.py
@@ -38,3 +38,11 @@ def fetch_page(session, page, page_size, timeout=DEFAULT_TIMEOUT, retries=DEFAUL
                 time.sleep(2 ** attempt)
     logger.error("Page %d failed after %d attempts; skipping", page, retries + 1)
     return None
+
+
+def compute_total_pages(total, page_size, max_pages=None):
+    """Number of pages needed for `total` items at `page_size`, optionally capped."""
+    pages = math.ceil(total / page_size) if total > 0 else 0
+    if max_pages is not None:
+        pages = min(pages, max_pages)
+    return pages

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -116,3 +116,26 @@ def test_iter_all_items_respects_max_pages(monkeypatch):
     monkeypatch.setattr(FBI, "fetch_page", lambda s, page, ps, **k: pages.get(page))
     items = list(FBI.iter_all_items(None, _cfg(page_size=1, max_pages=2)))
     assert [i["title"] for i in items] == ["a", "b"]
+
+
+def test_compute_total_pages_rejects_nonpositive_page_size():
+    with pytest.raises(ValueError):
+        FBI.compute_total_pages(100, 0)
+
+
+def test_iter_all_items_handles_total_zero(monkeypatch):
+    monkeypatch.setattr(FBI.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(FBI, "fetch_page", lambda s, page, ps, **k: {"total": 0, "items": []})
+    items = list(FBI.iter_all_items(None, _cfg()))
+    assert items == []
+
+
+def test_iter_all_items_handles_null_total(monkeypatch):
+    monkeypatch.setattr(FBI.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        FBI,
+        "fetch_page",
+        lambda s, page, ps, **k: {"total": None, "items": [{"title": "a"}]} if page == 1 else None,
+    )
+    items = list(FBI.iter_all_items(None, _cfg()))
+    assert [i["title"] for i in items] == ["a"]

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -1,5 +1,7 @@
+import argparse
 from unittest.mock import MagicMock
 
+import pytest
 import requests
 
 import FBI
@@ -52,3 +54,19 @@ def test_fetch_page_skips_on_bad_json(monkeypatch):
     result = FBI.fetch_page(session, 1, 20, retries=1)
     assert result is None
     assert session.get.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "total,size,expected",
+    [(999, 20, 50), (1000, 20, 50), (1001, 20, 51), (0, 20, 0), (1, 20, 1)],
+)
+def test_compute_total_pages(total, size, expected):
+    assert FBI.compute_total_pages(total, size) == expected
+
+
+def test_compute_total_pages_respects_cap():
+    assert FBI.compute_total_pages(1000, 20, max_pages=5) == 5
+
+
+def test_compute_total_pages_cap_above_total_is_ignored():
+    assert FBI.compute_total_pages(40, 20, max_pages=10) == 2

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -70,3 +70,49 @@ def test_compute_total_pages_respects_cap():
 
 def test_compute_total_pages_cap_above_total_is_ignored():
     assert FBI.compute_total_pages(40, 20, max_pages=10) == 2
+
+
+def _cfg(**kw):
+    base = dict(output="FBI.html", page_size=2, max_pages=None, delay=0, verbose=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_iter_all_items_spans_pages(monkeypatch):
+    monkeypatch.setattr(FBI.time, "sleep", lambda _s: None)
+    pages = {
+        1: {"total": 3, "items": [{"title": "a"}, {"title": "b"}]},
+        2: {"total": 3, "items": [{"title": "c"}]},
+    }
+    monkeypatch.setattr(FBI, "fetch_page", lambda s, page, ps, **k: pages.get(page))
+    items = list(FBI.iter_all_items(None, _cfg(page_size=2)))
+    assert [i["title"] for i in items] == ["a", "b", "c"]
+
+
+def test_iter_all_items_stops_when_first_page_fails(monkeypatch):
+    monkeypatch.setattr(FBI, "fetch_page", lambda s, page, ps, **k: None)
+    items = list(FBI.iter_all_items(None, _cfg()))
+    assert items == []
+
+
+def test_iter_all_items_skips_failed_middle_page(monkeypatch):
+    monkeypatch.setattr(FBI.time, "sleep", lambda _s: None)
+    pages = {
+        1: {"total": 6, "items": [{"title": "a"}, {"title": "b"}]},
+        2: None,  # failed page -> skipped
+        3: {"total": 6, "items": [{"title": "e"}, {"title": "f"}]},
+    }
+    monkeypatch.setattr(FBI, "fetch_page", lambda s, page, ps, **k: pages.get(page))
+    items = list(FBI.iter_all_items(None, _cfg(page_size=2)))
+    assert [i["title"] for i in items] == ["a", "b", "e", "f"]
+
+
+def test_iter_all_items_respects_max_pages(monkeypatch):
+    monkeypatch.setattr(FBI.time, "sleep", lambda _s: None)
+    pages = {
+        1: {"total": 100, "items": [{"title": "a"}]},
+        2: {"total": 100, "items": [{"title": "b"}]},
+    }
+    monkeypatch.setattr(FBI, "fetch_page", lambda s, page, ps, **k: pages.get(page))
+    items = list(FBI.iter_all_items(None, _cfg(page_size=1, max_pages=2)))
+    assert [i["title"] for i in items] == ["a", "b"]


### PR DESCRIPTION
## Bucket 2 of 5 — Pagination & Coverage

Stacks on Bucket 1. Replaces the hardcoded page loop with dynamic, total-driven pagination.

### Changes
- `compute_total_pages(total, page_size, max_pages=None)` — ceil division with optional cap; raises `ValueError` on non-positive `page_size`.
- `iter_all_items(session, cfg)` — generator that fetches page 1, derives page count from the API `total`, yields every item across all pages, skips failed pages (`continue`), stops early on empty pages (`break`), and throttles `cfg.delay` before each subsequent fetch.
- Guards both missing and explicit-null `total`.
- 18/18 tests passing (page-count math at ceil boundaries, multi-page iteration, failed-page skip, max-pages cap, total=0, null-total).

### Resolves
- Fix off-by-one: loop fetches only 9 pages, not 10
- Derive page count from API total instead of hardcoding
- Replace prints with Python logging module (logging woven into the fetch loop)

### Notes
- Reviewer follow-ups applied: null/zero-total guard, uniform throttle, `page_size` validation, log/compute ordering, extra regression tests.