### PR TITLE
Bucket 3: Defensive parsing & record rendering

### DIFF
--- a/FBI.py
+++ b/FBI.py
@@ -76,3 +76,29 @@ def iter_all_items(session, cfg):
             break
         for item in items:
             yield item
+
+
+def render_record(item):
+    """Render one wanted item as an HTML <article>. Returns "" if no usable fields."""
+    body = []
+
+    title = item.get("title")
+    if title:
+        body.append("<h2>{}</h2>".format(title))
+
+    path = item.get("path")
+    if path:
+        body.append('<p><a href="{0}">{0}</a></p>'.format(path))
+
+    subjects = item.get("subjects")
+    if subjects:
+        names = ", ".join(str(s) for s in subjects)
+        body.append("<p>Subjects: {}</p>".format(names))
+
+    caution = item.get("caution")
+    if isinstance(caution, str) and caution.strip():
+        body.append(caution.replace("<p> </p>", ""))
+
+    if not body:
+        return ""
+    return "<article>" + "".join(body) + "</article>"

--- a/FBI.py
+++ b/FBI.py
@@ -1,8 +1,10 @@
 """Fetch the FBI Most Wanted list and render it as an HTML page."""
 
 import argparse
+import html
 import logging
 import math
+import re
 import sys
 import time
 
@@ -84,20 +86,22 @@ def render_record(item):
 
     title = item.get("title")
     if title:
-        body.append("<h2>{}</h2>".format(title))
+        body.append("<h2>{}</h2>".format(html.escape(str(title))))
 
     path = item.get("path")
     if path:
-        body.append('<p><a href="{0}">{0}</a></p>'.format(path))
+        safe_path = html.escape(str(path), quote=True)
+        body.append('<p><a href="{0}">{0}</a></p>'.format(safe_path))
 
     subjects = item.get("subjects")
     if subjects:
-        names = ", ".join(str(s) for s in subjects)
-        body.append("<p>Subjects: {}</p>".format(names))
+        names = ", ".join(str(s) for s in subjects if s)
+        if names:
+            body.append("<p>Subjects: {}</p>".format(names))
 
     caution = item.get("caution")
     if isinstance(caution, str) and caution.strip():
-        body.append(caution.replace("<p> </p>", ""))
+        body.append(re.sub(r"<p>(?:\s|&nbsp;)*</p>", "", caution))
 
     if not body:
         return ""

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -139,3 +139,45 @@ def test_iter_all_items_handles_null_total(monkeypatch):
     )
     items = list(FBI.iter_all_items(None, _cfg()))
     assert [i["title"] for i in items] == ["a"]
+
+
+def test_render_record_full():
+    item = {
+        "title": "John Doe",
+        "path": "https://www.fbi.gov/wanted/x",
+        "subjects": ["Murder"],
+        "caution": "<p>Armed and dangerous</p>",
+    }
+    html = FBI.render_record(item)
+    assert html.startswith("<article>")
+    assert html.endswith("</article>")
+    assert "John Doe" in html
+    assert "https://www.fbi.gov/wanted/x" in html
+    assert "Murder" in html
+    assert "Armed and dangerous" in html
+
+
+def test_render_record_missing_caution_has_no_none():
+    item = {"title": "Jane", "path": "https://y", "subjects": ["Fraud"]}
+    html = FBI.render_record(item)
+    assert "Jane" in html
+    assert "None" not in html
+
+
+def test_render_record_missing_subjects_omits_section():
+    item = {"title": "Sam", "path": "https://z"}
+    html = FBI.render_record(item)
+    assert "Sam" in html
+    assert "Subjects" not in html
+    assert "[]" not in html
+
+
+def test_render_record_empty_returns_empty_string():
+    assert FBI.render_record({}) == ""
+
+
+def test_render_record_strips_empty_caution_paragraphs():
+    item = {"title": "T", "caution": "<p>Real</p><p> </p>"}
+    html = FBI.render_record(item)
+    assert "Real" in html
+    assert "<p> </p>" not in html

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -155,6 +155,8 @@ def test_render_record_full():
     assert "https://www.fbi.gov/wanted/x" in html
     assert "Murder" in html
     assert "Armed and dangerous" in html
+    assert "<h2>John Doe</h2>" in html
+    assert 'href="https://www.fbi.gov/wanted/x"' in html
 
 
 def test_render_record_missing_caution_has_no_none():
@@ -181,3 +183,28 @@ def test_render_record_strips_empty_caution_paragraphs():
     html = FBI.render_record(item)
     assert "Real" in html
     assert "<p> </p>" not in html
+
+
+def test_render_record_escapes_title():
+    out = FBI.render_record({"title": "John & <b>Jane</b>"})
+    assert "&amp;" in out
+    assert "<b>Jane</b>" not in out
+
+
+def test_render_record_escapes_path_quote():
+    out = FBI.render_record({"title": "T", "path": 'https://x"onmouseover=1'})
+    assert "&quot;" in out
+    assert '"onmouseover' not in out
+
+
+def test_render_record_skips_none_subjects():
+    out = FBI.render_record({"title": "T", "subjects": ["Murder", None, "Fraud"]})
+    assert "Murder, Fraud" in out
+    assert "None" not in out
+
+
+def test_render_record_strips_empty_paragraphs_between_content():
+    out = FBI.render_record({"title": "T", "caution": "<p>Real</p><p>  </p><p>More</p>"})
+    assert "Real" in out
+    assert "More" in out
+    assert "<p>  </p>" not in out


### PR DESCRIPTION
## Bucket 3 of 5 — Defensive Parsing & Record Rendering

Stacks on Bucket 2. Adds safe, all-records rendering of individual wanted items.

### Changes
- `render_record(item)` — pure function rendering one item to an HTML `<article>` using `.get()` for every field (no KeyErrors), including all records (no caution-only filter), omitting missing/empty sub-elements, returning "" only when nothing usable.
- HTML-escapes `title` (text) and `path` (attribute, `quote=True`); filters `None`/empty `subjects`; strips empty `<p>` paragraphs via regex covering whitespace and `&nbsp;`.
- `caution`/`subjects` HTML kept as trusted markup per the documented design decision.
- 27/27 tests passing (full/partial/empty items, XSS escaping, null-subject filtering, multi-paragraph stripping).

### Resolves
- Guard against missing dict keys when reading API items
- Replace `!= None` comparison with `is not None` (eliminated entirely — no such comparisons remain; safe `.get()` + truthiness used)

### Notes
- Reviewer follow-ups applied: escape title/path, robust empty-paragraph regex, filter null subjects, added structural + edge-case tests.