### PR TITLE
Bucket 4: File handling (context manager + UTF-8)

### DIFF
--- a/FBI.py
+++ b/FBI.py
@@ -106,3 +106,9 @@ def render_record(item):
     if not body:
         return ""
     return "<article>" + "".join(body) + "</article>"
+
+
+def write_output(document, path):
+    """Write the HTML document to `path` as UTF-8, closing the file even on error."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(document)

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -208,3 +208,9 @@ def test_render_record_strips_empty_paragraphs_between_content():
     assert "Real" in out
     assert "More" in out
     assert "<p>  </p>" not in out
+
+
+def test_write_output_roundtrip_utf8(tmp_path):
+    p = tmp_path / "out.html"
+    FBI.write_output("<p>José Peña — café</p>", str(p))
+    assert p.read_text(encoding="utf-8") == "<p>José Peña — café</p>"


### PR DESCRIPTION
## Bucket 4 of 5 — File Handling

Stacks on Bucket 3. Replaces the legacy manual `open(...)`/`f.close()` (no encoding) with a safe writer.

### Changes
- `write_output(document, path)` — writes the document via `with open(path, "w", encoding="utf-8")`, guaranteeing the handle closes even on a mid-write exception, and writing UTF-8 explicitly (no platform-default encoding).
- Parameter named `document` (not `html`) to avoid shadowing the module-level `import html`.
- `OSError` deliberately propagates to the caller; `main` (Bucket 5) owns the catch.
- 28/28 tests passing, incl. a UTF-8 round-trip with accented characters.

### Resolves
- Use a context manager so the file closes on exceptions
- Specify UTF-8 encoding when opening the output file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to save generated HTML documents to files with full UTF-8 encoding support, ensuring proper handling of Unicode characters and non-ASCII text.

* **Tests**
  * Added comprehensive test coverage validating UTF-8 file output for Unicode character preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->