### PR TITLE
Bucket 5: HTML output quality + final assembly (CLI/main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+FBI.html
+.project-hub-tasks.json

--- a/FBI.py
+++ b/FBI.py
@@ -112,3 +112,28 @@ def write_output(document, path):
     """Write the HTML document to `path` as UTF-8, closing the file even on error."""
     with open(path, "w", encoding="utf-8") as f:
         f.write(document)
+
+
+def build_document(articles):
+    """Wrap rendered <article> strings in a complete, valid HTML5 document."""
+    body = "\n".join(a for a in articles if a)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>FBI Most Wanted</title>\n"
+        "<style>\n"
+        "body { font-family: system-ui, sans-serif; max-width: 800px;"
+        " margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }\n"
+        "article { border-bottom: 1px solid #ccc; padding: 1rem 0; }\n"
+        "h1 { font-size: 1.6rem; }\n"
+        "h2 { font-size: 1.2rem; margin: 0 0 .5rem; }\n"
+        "</style>\n"
+        "</head>\n"
+        "<body>\n"
+        "<h1>FBI Most Wanted</h1>\n"
+        + body
+        + "\n</body>\n</html>\n"
+    )

--- a/FBI.py
+++ b/FBI.py
@@ -137,3 +137,40 @@ def build_document(articles):
         + body
         + "\n</body>\n</html>\n"
     )
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Fetch the FBI Most Wanted list and write it to an HTML file."
+    )
+    parser.add_argument("--output", default=DEFAULT_OUTPUT, help="Output HTML path.")
+    parser.add_argument("--page-size", type=int, default=DEFAULT_PAGE_SIZE, help="Items per page.")
+    parser.add_argument("--max-pages", type=int, default=None, help="Optional cap on pages fetched.")
+    parser.add_argument("--delay", type=float, default=DEFAULT_DELAY, help="Seconds between pages.")
+    parser.add_argument("--verbose", action="store_true", help="Enable DEBUG logging.")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    cfg = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if cfg.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    session = requests.Session()
+    session.headers.update({"User-Agent": USER_AGENT})
+    articles = [render_record(item) for item in iter_all_items(session, cfg)]
+    rendered = [a for a in articles if a]
+    logger.info("Rendered %d record(s)", len(rendered))
+    document = build_document(rendered)
+    try:
+        write_output(document, cfg.output)
+    except OSError as exc:
+        logger.error("Failed to write %s: %s", cfg.output, exc)
+        return 1
+    logger.info("Wrote %s", cfg.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/FBI.py
+++ b/FBI.py
@@ -95,7 +95,7 @@ def render_record(item):
 
     subjects = item.get("subjects")
     if subjects:
-        names = ", ".join(str(s) for s in subjects if s)
+        names = ", ".join(html.escape(str(s)) for s in subjects if s)
         if names:
             body.append("<p>Subjects: {}</p>".format(names))
 

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -148,30 +148,30 @@ def test_render_record_full():
         "subjects": ["Murder"],
         "caution": "<p>Armed and dangerous</p>",
     }
-    html = FBI.render_record(item)
-    assert html.startswith("<article>")
-    assert html.endswith("</article>")
-    assert "John Doe" in html
-    assert "https://www.fbi.gov/wanted/x" in html
-    assert "Murder" in html
-    assert "Armed and dangerous" in html
-    assert "<h2>John Doe</h2>" in html
-    assert 'href="https://www.fbi.gov/wanted/x"' in html
+    out = FBI.render_record(item)
+    assert out.startswith("<article>")
+    assert out.endswith("</article>")
+    assert "John Doe" in out
+    assert "https://www.fbi.gov/wanted/x" in out
+    assert "Murder" in out
+    assert "Armed and dangerous" in out
+    assert "<h2>John Doe</h2>" in out
+    assert 'href="https://www.fbi.gov/wanted/x"' in out
 
 
 def test_render_record_missing_caution_has_no_none():
     item = {"title": "Jane", "path": "https://y", "subjects": ["Fraud"]}
-    html = FBI.render_record(item)
-    assert "Jane" in html
-    assert "None" not in html
+    out = FBI.render_record(item)
+    assert "Jane" in out
+    assert "None" not in out
 
 
 def test_render_record_missing_subjects_omits_section():
     item = {"title": "Sam", "path": "https://z"}
-    html = FBI.render_record(item)
-    assert "Sam" in html
-    assert "Subjects" not in html
-    assert "[]" not in html
+    out = FBI.render_record(item)
+    assert "Sam" in out
+    assert "Subjects" not in out
+    assert "[]" not in out
 
 
 def test_render_record_empty_returns_empty_string():
@@ -237,14 +237,16 @@ def test_parse_args_defaults():
     assert cfg.page_size == 20
     assert cfg.max_pages is None
     assert cfg.verbose is False
+    assert cfg.delay == 0.25
 
 
 def test_parse_args_overrides():
-    cfg = FBI.parse_args(["--output", "o.html", "--page-size", "50", "--max-pages", "3", "--verbose"])
+    cfg = FBI.parse_args(["--output", "o.html", "--page-size", "50", "--max-pages", "3", "--verbose", "--delay", "0.5"])
     assert cfg.output == "o.html"
     assert cfg.page_size == 50
     assert cfg.max_pages == 3
     assert cfg.verbose is True
+    assert cfg.delay == 0.5
 
 
 def test_main_writes_document(monkeypatch, tmp_path):
@@ -262,8 +264,24 @@ def test_main_writes_document(monkeypatch, tmp_path):
 
 def test_main_returns_nonzero_on_write_error(monkeypatch):
     monkeypatch.setattr(FBI, "iter_all_items", lambda session, cfg: iter([{"title": "T"}]))
+
     def boom(document, path):
         raise OSError("disk full")
+
     monkeypatch.setattr(FBI, "write_output", boom)
-    rc = FBI.main(["--output", "/nonexistent/dir/out.html"])
+    # write_output is patched to raise, so the output path is irrelevant to this test.
+    rc = FBI.main([])
     assert rc == 1
+
+
+def test_main_sets_user_agent(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_iter(session, cfg):
+        captured["ua"] = session.headers.get("User-Agent")
+        return iter([])
+
+    monkeypatch.setattr(FBI, "iter_all_items", fake_iter)
+    rc = FBI.main(["--output", str(tmp_path / "o.html")])
+    assert rc == 0
+    assert captured["ua"] == FBI.USER_AGENT

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -229,3 +229,41 @@ def test_build_document_filters_empty_articles():
     doc = FBI.build_document(["", "<article>y</article>", ""])
     assert "<article>y</article>" in doc
     assert "<article></article>" not in doc
+
+
+def test_parse_args_defaults():
+    cfg = FBI.parse_args([])
+    assert cfg.output == "FBI.html"
+    assert cfg.page_size == 20
+    assert cfg.max_pages is None
+    assert cfg.verbose is False
+
+
+def test_parse_args_overrides():
+    cfg = FBI.parse_args(["--output", "o.html", "--page-size", "50", "--max-pages", "3", "--verbose"])
+    assert cfg.output == "o.html"
+    assert cfg.page_size == 50
+    assert cfg.max_pages == 3
+    assert cfg.verbose is True
+
+
+def test_main_writes_document(monkeypatch, tmp_path):
+    out = tmp_path / "FBI.html"
+    monkeypatch.setattr(
+        FBI, "iter_all_items",
+        lambda session, cfg: iter([{"title": "Target", "path": "https://p"}]),
+    )
+    rc = FBI.main(["--output", str(out)])
+    assert rc == 0
+    content = out.read_text(encoding="utf-8")
+    assert content.startswith("<!DOCTYPE html>")
+    assert "Target" in content
+
+
+def test_main_returns_nonzero_on_write_error(monkeypatch):
+    monkeypatch.setattr(FBI, "iter_all_items", lambda session, cfg: iter([{"title": "T"}]))
+    def boom(document, path):
+        raise OSError("disk full")
+    monkeypatch.setattr(FBI, "write_output", boom)
+    rc = FBI.main(["--output", "/nonexistent/dir/out.html"])
+    assert rc == 1

--- a/tests/test_fbi.py
+++ b/tests/test_fbi.py
@@ -214,3 +214,18 @@ def test_write_output_roundtrip_utf8(tmp_path):
     p = tmp_path / "out.html"
     FBI.write_output("<p>José Peña — café</p>", str(p))
     assert p.read_text(encoding="utf-8") == "<p>José Peña — café</p>"
+
+
+def test_build_document_structure():
+    doc = FBI.build_document(["<article>x</article>"])
+    assert doc.startswith("<!DOCTYPE html>")
+    assert 'charset="utf-8"' in doc
+    assert "<title>FBI Most Wanted</title>" in doc
+    assert "<article>x</article>" in doc
+    assert doc.rstrip().endswith("</html>")
+
+
+def test_build_document_filters_empty_articles():
+    doc = FBI.build_document(["", "<article>y</article>", ""])
+    assert "<article>y</article>" in doc
+    assert "<article></article>" not in doc


### PR DESCRIPTION
## Bucket 5 of 5 — HTML Output Quality + Final Assembly

Final bucket. Completes the module: valid structured HTML output, the argparse CLI, and the `main` orchestrator.

### Changes
- `build_document(articles)` — wraps rendered `<article>` blocks in a complete HTML5 document (`<!DOCTYPE html>`, `charset=utf-8`, viewport, title, light inline CSS), filtering empties.
- `parse_args(argv)` — argparse CLI: `--output`, `--page-size`, `--max-pages`, `--delay`, `--verbose`.
- `main(argv)` — orchestrates fetch → render → build → write; configures logging (`--verbose` → DEBUG); sets a descriptive `User-Agent`; returns `0` on success, `1` on write `OSError`. Plus the `__main__` entrypoint.
- `.gitignore` for generated output and caches.
- Reviewer follow-up: `subjects` are now HTML-escaped (they are plain-text categories, not HTML — corrects an earlier assumption); added `--delay`/User-Agent test coverage; de-shadowed `html` locals in tests.
- 35/35 tests passing. Live smoke test passed: `python3 FBI.py --max-pages 1` → exit 0, 20 records rendered (API reported 1172 total).

### Resolves
- Wrap output in valid HTML document structure
- Add pytest suite for fetch, pagination, rendering, and output

### Notes
- All Bucket 1 scaffold imports (argparse/math/sys/html/re) are now fully consumed.